### PR TITLE
Add index.html mvp code and about_us.html page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+<center>
+	<h1><p>
+		The Evolution of Fake News
+	</p></h1>
+	<h2><p><i>
+		(Working Title)
+	</i></p></h2>
+	<h3><p>
+		By Oliver Backes, Arjun Bisen, Alex Bullock, Simon Jones, and Jake Rashbass.
+		<br><br>
+		Created for DPI 691M: Programming and Data for Policymakers at the Harvard Kennedy School of Government
+	</p></h3>
+</center>
+
+<p>
+	Insert introductory text regarding fake news, purposes of the project, and issues investigated.
+</p>
+
+<h3><p>
+	Structure of this site: 
+</h3>
+	On this site, you will find five separate data visualizations on five separate, linked pages. Each of these visualizations will analyze and present data on some aspect of the phenomenon of fake news, potentially including (but not limited to) investigations of the ways in which fake news spreads, the ability of prominent figures to promote fake news, and the impact of fake news on public perceptions of the press, politics, and truth. Additionally, the site will contain an "About Us" page, with a detailed biography of each of the project team members.
+</p>
+
+<p>
+	The five visualizations and "About Us" pages will be accessible via a menu bar at the top of the site. This menu bar will appear on each page of the site, allowing end users the ability to navigate from page to page quickly and easily. Below you will find a (very) loose over view of what such a menu bar might look like:
+</p>
+
+<p>
+	<table border="5" width=100%>
+		<tr align=center>
+			<td><a href="index.html">Home Page</a></td>
+			<td><a href="visualization_1.html">Visualization 1</a></td>
+			<td><a href="visualization_2.html">Visualization 2</a></td>
+			<td><a href="visualization_3.html">Visualization 3</a></td>
+			<td><a href="visualization_4.html">Visualization 4</a></td>
+			<td><a href="visualization_5.html">Visualization 5</a></td>
+			<td><a href="about_us.html">About Us</a></td>
+		</tr>
+	</table>
+</p>
+
+</body>
+</html>


### PR DESCRIPTION
Two commits contained herein:
1) I wrote up some code for a MVP version of the index.html page; and
2) I added an additional blank page called about_us.html.